### PR TITLE
Corregir los problemas detectados por PHPStan (1.1.2)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,15 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
 versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente se tratan de cambios en el desarrollo.
 
+## Versión 0.2.1 2021-11-16 *Happy birthday Noni*
+
+La versión más reciente de PHPStan `phpstan/phpstan:1.1.2` encontró algunos puntos de mejora
+y uno que otro falso positivo. Se hacen las correcciones:
+
+- `AntiCaptchaConnector`: Se previene un error de ejecución al verificar la respuesta del servidor.
+- `CaptchaLocalResolverConnector`: Se previene un error de ejecución al verificar la respuesta del servidor.
+- Se eliminan asignaciones superfluas al usar el operador `Null coalescing`.
+
 ## Versión 0.2.0 2021-07-28
 
 Se agrega el resolvedor `CommandLineResolver` que pasa la imagen del captcha como un archivo temporal

--- a/src/CaptchaAnswer.php
+++ b/src/CaptchaAnswer.php
@@ -30,7 +30,7 @@ final class CaptchaAnswer implements JsonSerializable, CaptchaAnswerInterface
     public function equalsTo($value): bool
     {
         try {
-            return $this->value === (string) $value;
+            return $this->value === strval($value);
         } catch (Throwable $ex) {
             return false;
         }

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -140,7 +140,12 @@ final class HttpClient implements HttpClientInterface
         return new class($exception) extends RuntimeException implements ClientExceptionInterface {
             public function __construct(Throwable $previous)
             {
-                parent::__construct($previous->getMessage(), $previous->getCode(), $previous);
+                /**
+                 * @see https://github.com/phpstan/phpstan-src/pull/767
+                 * @var int|string $code
+                 */
+                $code = $previous->getCode();
+                parent::__construct($previous->getMessage(), (int) $code, $previous);
             }
         };
     }

--- a/src/Resolvers/AntiCaptchaResolver/AntiCaptchaConnector.php
+++ b/src/Resolvers/AntiCaptchaResolver/AntiCaptchaConnector.php
@@ -112,6 +112,9 @@ class AntiCaptchaConnector
         }
 
         $result = json_decode((string) $response->getBody());
+        if (! $result instanceof stdClass) {
+            $result = (object) ['errorId' => 1, 'errorDescription' => 'Response is not a JSON object'];
+        }
         $errorId = intval($result->errorId ?? 0);
         if ($errorId > 0) {
             throw new RuntimeException(

--- a/src/Resolvers/CaptchaLocalResolver/CaptchaLocalResolverConnector.php
+++ b/src/Resolvers/CaptchaLocalResolver/CaptchaLocalResolverConnector.php
@@ -86,7 +86,7 @@ class CaptchaLocalResolverConnector
         }
         $contents = strval($response->getBody());
         $data = json_decode($contents, true);
-        $code = strval($data['code'] ?? '');
+        $code = (is_array($data)) ? strval($data['code'] ?? '') : '';
         if ('' === $code) {
             throw new RuntimeException('Image was sent but service returns empty code');
         }
@@ -118,7 +118,7 @@ class CaptchaLocalResolverConnector
         }
         $contents = strval($response->getBody());
         $data = json_decode($contents, true);
-        return strval($data['answer'] ?? '');
+        return (is_array($data)) ? strval($data['answer'] ?? '') : '';
     }
 
     public function buildUri(string $action): string

--- a/src/Resolvers/CommandLineResolver.php
+++ b/src/Resolvers/CommandLineResolver.php
@@ -43,8 +43,8 @@ final class CommandLineResolver implements CaptchaResolverInterface
             throw new LogicException('Command cannot be "{file}"');
         }
         $this->command = $command;
-        $this->answerBuilder = $answerBuilder ?? new CommandLineResolver\LastLineAnswerBuilder();
-        $this->processRunner = $processRunner ?? new CommandLineResolver\SymfonyProcessRunner();
+        $this->answerBuilder = $answerBuilder;
+        $this->processRunner = $processRunner;
     }
 
     /**

--- a/tests/Extending/HasPreviousException.php
+++ b/tests/Extending/HasPreviousException.php
@@ -32,8 +32,8 @@ class HasPreviousException extends Constraint
             '%s &%s has previous exception %s &%s',
             get_class($this->exception),
             spl_object_hash($this->exception),
-            get_class($other),
-            spl_object_hash($other),
+            (is_object($other)) ? get_class($other) : gettype($other),
+            (is_object($other)) ? spl_object_hash($other) : '',
         );
     }
 

--- a/tests/HttpTestCase.php
+++ b/tests/HttpTestCase.php
@@ -42,11 +42,7 @@ abstract class HttpTestCase extends TestCase
 
     protected function createHttpClient(ClientInterface $client): HttpClientInterface
     {
-        return new HttpClient(
-            $client ?? $this->createPhpHttpMockClient(),
-            $this->requestFactory,
-            $this->streamFactory
-        );
+        return new HttpClient($client, $this->requestFactory, $this->streamFactory);
     }
 
     /**

--- a/tests/Integration/AntiCaptchaResolver/AntiCaptchaResolverUsageTest.php
+++ b/tests/Integration/AntiCaptchaResolver/AntiCaptchaResolverUsageTest.php
@@ -13,7 +13,7 @@ final class AntiCaptchaResolverUsageTest extends TestCase
 {
     public function checkTestIsEnabled(): void
     {
-        if ('yes' !== $this->getenv('ANTI_CAPTCHA_ENABLED') ?? '') {
+        if ('yes' !== $this->getenv('ANTI_CAPTCHA_ENABLED')) {
             $this->markTestSkipped('Anti-captcha resolver tests are not enabled');
         }
     }

--- a/tests/Integration/CaptchaLocalResolver/CaptchaLocalResolverUsageTest.php
+++ b/tests/Integration/CaptchaLocalResolver/CaptchaLocalResolverUsageTest.php
@@ -18,11 +18,11 @@ final class CaptchaLocalResolverUsageTest extends TestCase
     {
         parent::setUp();
 
-        if ('yes' !== $this->getenv('CAPTCHA_LOCAL_RESOLVER_ENABLED') ?? '') {
+        if ('yes' !== $this->getenv('CAPTCHA_LOCAL_RESOLVER_ENABLED')) {
             $this->markTestSkipped('Captcha local resolver tests are not enabled');
         }
 
-        $localResolverUrl = $this->getenv('CAPTCHA_LOCAL_RESOLVER_BASEURL') ?? '';
+        $localResolverUrl = $this->getenv('CAPTCHA_LOCAL_RESOLVER_BASEURL');
         if ('' === $localResolverUrl) {
             $this->fail('Environment CAPTCHA_LOCAL_RESOLVER_BASEURL is not set');
         }

--- a/tests/Unit/Resolvers/AntiCaptchaResolver/AntiCaptchaConnectorTest.php
+++ b/tests/Unit/Resolvers/AntiCaptchaResolver/AntiCaptchaConnectorTest.php
@@ -12,6 +12,7 @@ use PhpCfdi\ImageCaptchaResolver\Resolvers\AntiCaptchaResolver\AntiCaptchaConnec
 use PhpCfdi\ImageCaptchaResolver\Tests\Extending\AssertHasPreviousExceptionTrait;
 use PhpCfdi\ImageCaptchaResolver\Tests\HttpTestCase;
 use RuntimeException;
+use stdClass;
 
 final class AntiCaptchaConnectorTest extends HttpTestCase
 {
@@ -55,6 +56,7 @@ final class AntiCaptchaConnectorTest extends HttpTestCase
         $this->assertSame($expectedTaskId, $taskId);
 
         $lastRequest = $phpHttpMockClient->getLastRequest();
+        /** @var stdClass $sentValues */
         $sentValues = json_decode((string) $lastRequest->getBody());
         $this->assertSame($this->clientKey, $sentValues->clientKey ?? '');
         $this->assertSame('ImageToTextTask', $sentValues->task->type ?? '');


### PR DESCRIPTION
La versión más reciente de PHPStan `phpstan/phpstan:1.1.2` encontró algunos puntos de mejora
y uno que otro falso positivo. Se hacen las correcciones:

- `AntiCaptchaConnector`: Se previene un error de ejecución al verificar la respuesta del servidor.
- `CaptchaLocalResolverConnector`: Se previene un error de ejecución al verificar la respuesta del servidor.
- Se eliminan asignaciones superfluas al usar el operador `Null coalescing`.