### PR TITLE
Mantenimiento 2023-05-25 (Version 0.2.3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
       - name: Code style (phpcs)
@@ -57,7 +57,7 @@ jobs:
         with:
           php-version: '8.2'
           coverage: none
-          tools: composer:v2, cs2pr, php-cs-fixer
+          tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -110,7 +110,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer-normalize
         env:
@@ -38,7 +38,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, cs2pr, phpcs
         env:
@@ -55,7 +55,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, cs2pr, php-cs-fixer
         env:
@@ -72,7 +72,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, cs2pr, phpstan
         env:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,7 +25,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -53,15 +53,15 @@ jobs:
         id: check-secrets
         run: |
           if [ -n "${{ secrets.GITHUB_TOKEN }}" ]; then
-            echo "::set-output name=github::yes"
+            echo "github=yes" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=github::no"
+            echo "github=no" >> $GITHUB_OUTPUT
             echo "::warning ::GITHUB_TOKEN non set"
           fi
           if [ -n "${{ secrets.SONAR_TOKEN }}" ]; then
-            echo "::set-output name=sonar::yes"
+            echo "sonar=yes" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=sonar::no"
+            echo "sonar=no" >> $GITHUB_OUTPUT
             echo "::warning ::SONAR_TOKEN non set"
           fi
 
@@ -83,7 +83,7 @@ jobs:
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: xdebug
           tools: composer:v2
         env:
@@ -78,7 +78,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.7.1" location="./tools/phpcs" copy="false" installed="3.7.1"/>
-  <phar name="phpcbf" version="^3.7.1" location="./tools/phpcbf" copy="false" installed="3.7.1"/>
-  <phar name="php-cs-fixer" version="^3.13.0" location="./tools/php-cs-fixer" copy="false" installed="3.13.0"/>
-  <phar name="phpstan" version="^1.9.1" location="./tools/phpstan" copy="false" installed="1.9.1"/>
-  <phar name="composer-normalize" version="^2.28.3" location="./tools/composer-normalize" copy="false" installed="2.28.3"/>
+  <phar name="phpcs" version="^3.7.2" location="./tools/phpcs" copy="false" installed="3.7.2"/>
+  <phar name="phpcbf" version="^3.7.2" location="./tools/phpcbf" copy="false" installed="3.7.2"/>
+  <phar name="php-cs-fixer" version="^3.17.0" location="./tools/php-cs-fixer" copy="false" installed="3.17.0"/>
+  <phar name="phpstan" version="^1.10.15" location="./tools/phpstan" copy="false" installed="1.10.15"/>
+  <phar name="composer-normalize" version="^2.31.0" location="./tools/composer-normalize" copy="false" installed="2.31.0"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021 - 2022 PhpCfdi https://www.phpcfdi.com
+Copyright (c) 2021 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-php-version]: https://img.shields.io/packagist/php-v/phpcfdi/image-captcha-resolver?logo=php
 [badge-release]: https://img.shields.io/github/release/phpcfdi/image-captcha-resolver?logo=git
 [badge-license]: https://img.shields.io/github/license/phpcfdi/image-captcha-resolver?logo=open-source-initiative
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/image-captcha-resolver/build/main?logo=github-actions
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/image-captcha-resolver/build.yml?branch=main&logo=github-actions
 [badge-reliability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_image-captcha-resolver&metric=reliability_rating
 [badge-maintainability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_image-captcha-resolver&metric=sqale_rating
 [badge-coverage]: https://img.shields.io/sonar/coverage/phpcfdi_image-captcha-resolver/main?logo=sonarcloud&server=https%3A%2F%2Fsonarcloud.io

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php-http/discovery": "^1.14",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.1 || ^2.0",
         "symfony/polyfill-php80": "^1.23"
     },
     "require-dev": {
@@ -49,6 +49,9 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        },
         "optimize-autoloader": true,
         "preferred-install": {
             "*": "dist"

--- a/composer.json
+++ b/composer.json
@@ -60,16 +60,16 @@
             "@dev:test"
         ],
         "dev:check-style": [
-            "@php tools/composer-normalize normalize --dry-run",
-            "@php tools/php-cs-fixer fix --dry-run --verbose",
+            "@php -r 'exit(intval(PHP_VERSION_ID >= 80000));' || $PHP_BINARY tools/composer-normalize normalize --dry-run",
+            "@php -r 'exit(intval(PHP_VERSION_ID >= 74000));' || $PHP_BINARY tools/php-cs-fixer fix --dry-run --verbose || true",
             "@php tools/phpcs --colors -sp"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
         ],
         "dev:fix-style": [
-            "@php tools/composer-normalize normalize",
-            "@php tools/php-cs-fixer fix --verbose",
+            "@php -r 'exit(intval(PHP_VERSION_ID >= 80000));' || $PHP_BINARY tools/composer-normalize normalize",
+            "@php -r 'exit(intval(PHP_VERSION_ID >= 74000));' || $PHP_BINARY tools/php-cs-fixer fix --verbose",
             "@php tools/phpcbf --colors -sp"
         ],
         "dev:test": [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,23 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
 versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente, se tratan de cambios en el desarrollo.
 
+## Versión 0.2.3 2023-05-25
+
+- Se actualizó la dependencia `psr/http-message` para permitir las versiones `^1.1` o `^2.0`.
+- Se actualizó el año de la licencia.
+- Se corrigió la insignia de la construcción del proyecto.
+- Se corrigió la insignia de la construcción del proyecto.
+
+Se hicieron varios cambios de mantenimiento al entorno de desarrollo:
+
+- En los flujos de trabajo de GitHub:
+  - Los trabajos se ejecutan en PHP 8.2.
+  - Se cambia la directiva `::set-output` por `$GITHUB_OUTPUT`.
+  - Se elimina el requerimiento de `composer` en los trabajos donde no es necesario.
+- La ejecución de `composer-normalize` se condiciona a una versión mínima de PHP 8.0.
+- La ejecución de `php-cs-fixer` se condiciona a una versión mínima de PHP 7.4.
+- Se actualizaron las herramientas de desarrollo.
+
 ## Versión 0.2.2 2022-11-16 *Happy pre-birthday Noni*
 
 Este es una liberación de mantenimiento, el cambio más importante es la corrección de un posible problema


### PR DESCRIPTION
- Se actualizó la dependencia `psr/http-message` para permitir las versiones `^1.1` o `^2.0`.
- Se actualizó el año de la licencia.
- Se corrigió la insignia de la construcción del proyecto.
- Se corrigió la insignia de la construcción del proyecto.

Se hicieron varios cambios de mantenimiento al entorno de desarrollo:

- En los flujos de trabajo de GitHub:
  - Los trabajos se ejecutan en PHP 8.2.
  - Se cambia la directiva `::set-output` por `$GITHUB_OUTPUT`.
  - Se elimina el requerimiento de `composer` en los trabajos donde no es necesario.
- La ejecución de `composer-normalize` se condiciona a una versión mínima de PHP 8.0.
- La ejecución de `php-cs-fixer` se condiciona a una versión mínima de PHP 7.4.
- Se actualizaron las herramientas de desarrollo.
