### PR TITLE
Remover `tests/.env`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2 # see https://github.com/marketplace/actions/setup-php-action
+        uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
           coverage: none

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /vendor/
 /composer.lock
 .phpunit.result.cache
+/tests/.env

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,7 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 Pueden aparecer cambios no liberados que se integran a la rama principal, pero no ameritan una nueva liberación de
 versión, aunque sí su incorporación en la rama principal de trabajo. Generalmente, se tratan de cambios en el desarrollo.
 
-## Versión 0.2.4 2023-05-25
+## Versión 0.2.4 2024-10-03
 
 - Se agrega la compatibilidad de `symfony/process` a las versiones `6.x` y `7.x`.
 - Se actualizó el año de la licencia.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ versión, aunque sí su incorporación en la rama principal de trabajo. Generalm
 
 Cambios de mantenimiento al entorno de desarrollo:
 
+- Se remueve el archivo `tests/.env` que solía tener la llave de la API de AntiCaptcha.
+- Ignorar `tests/.env` de Git.
 - Se agrega el archivo `.editorconfig` para mejorar la compatibilidad.
 - Se excluye `tests/_files` de la detección de lenguaje de GitHub.
 - Se sustituye `function_typehint_space` con `type_declaration_spaces` en `php-cs-fixer`.

--- a/tests/.env
+++ b/tests/.env
@@ -1,7 +1,0 @@
-# local resolver configuration - https://github.com/eclipxe13/captcha-local-resolver
-CAPTCHA_LOCAL_RESOLVER_ENABLED="no"
-CAPTCHA_LOCAL_RESOLVER_BASEURL="http://localhost:9095"
-
-# Anti-captcha configuration - https://anti-captcha.com/
-ANTI_CAPTCHA_ENABLED="no"
-ANTI_CAPTCHA_CLIENT_KEY="eea0339b6e45e3d3c797bd16a3e77bc4"

--- a/tests/.env.example
+++ b/tests/.env.example
@@ -4,4 +4,4 @@ CAPTCHA_LOCAL_RESOLVER_BASEURL="http://localhost:9095"
 
 # Anti-captcha configuration - https://anti-captcha.com/
 ANTI_CAPTCHA_ENABLED="no"
-ANTI_CAPTCHA_CLIENT_KEY="eea0339b6e45e3d3c797bd16a3e77bc4"
+ANTI_CAPTCHA_CLIENT_KEY=""

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,8 @@ error_reporting(-1);
 require_once __DIR__ . '/../vendor/autoload.php';
 
 (function (): void {
-    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
-    $dotenv->load();
+    if (file_exists(__DIR__ . '/.env')) {
+        $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+        $dotenv->load();
+    }
 })();


### PR DESCRIPTION
- Se remueve el archivo `tests/.env` que solía tener la llave de la API de AntiCaptcha.
- Ignorar `tests/.env` de Git.

Nota: Incluir estos cambios antes de liberar la versión 0.2.4.