### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "php-http/discovery": "^1.14",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.1 || ^2.0",
-        "symfony/polyfill-php80": "^1.23"
+        "psr/http-message": "^1.1 || ^2.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.3",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: >=8.2`, so the polyfill requirement doesn't seem necessary anymore?